### PR TITLE
Update package.json to allow webpack bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-admob",
   "version": "1.2.0",
   "description": "Make money with your app by using Google's AdMob ads.",
-  "main": "admob.js",
+  "main": "admob",
   "nativescript": {
     "platforms": {
       "android": "2.3.0",


### PR DESCRIPTION
We released a new version of the NS webpack plugin [NS webpack plugin](https://github.com/NativeScript/nativescript-dev-webpack) today.  That change is necessary for the plugin to be compatible with it. The `.js` extension of the `main` property in the `package.json` should be removed. That way, webpack will be able to correctly reference the android or ios main file.

Check out the [Webpack article](http://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson) in the NativeScript  documentation. 