### PR TITLE
Allow project to override google services version

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -7,5 +7,6 @@ android {
 }
 
 dependencies {
-    compile "com.google.android.gms:play-services-ads:+"
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '+'
+    compile "com.google.android.gms:play-services-ads:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
This change is needed to coordinate google services versions in conjunction with nativescript-social-login.
This change does not alter the default behavior of nativescript-admob.