### PR TITLE
Sending a view property will place ad in that view

### DIFF
--- a/src/admob.ios.js
+++ b/src/admob.ios.js
@@ -84,8 +84,10 @@ admob.createBanner = function (arg) {
         admob.adView.removeFromSuperview();
         admob.adView = null;
       }
-
-      admob.defaults.view = utils.ios.getter(UIApplication, UIApplication.sharedApplication).keyWindow.rootViewController.view;
+      // If args doesn't have a view we add the advertisement to the view of the root ViewController.
+      if (arg.view === null || arg.view === undefined) {
+        admob.defaults.view = utils.ios.getter(UIApplication, UIApplication.sharedApplication).keyWindow.rootViewController.view;
+      }
       var settings = admob.merge(arg, admob.defaults);
       var view = settings.view;
       var bannerType = admob._getBannerType(settings.size);


### PR DESCRIPTION
This will place the advertisement in the view you send. Before, that view would always get overwritten by the view of the rootViewController. Now, it simply checks if the view is present, and if it isn't it will take the key window.