### PR TITLE
Socket connection timed out issue caused by Google Mobile Ads SDK version 17

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -11,6 +11,6 @@ repositories {
 }
 
 dependencies {
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '+'
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '16.0.0'
     compile "com.google.android.gms:play-services-ads:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
Resolves inability to run app due to socket connection timed out issues following release of Google Mobile Ads SDK version 17.0.0.

Discussed [here](https://github.com/NativeScript/nativescript-cli/issues/4029#issuecomment-430192531).

Credit for solution: @Fatme