### PR TITLE
fix: works correctly with sdk version 17.0.0

### DIFF
--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -5,7 +5,7 @@ purpose of the file is to pass control to the app’s first module.
 */
 
 import "./bundle-config";
-import * as application from 'application';
+import * as application from 'tns-core-modules/application';
 
 application.run({ moduleName: 'app-root' });
 

--- a/src/admob.android.js
+++ b/src/admob.android.js
@@ -1,6 +1,6 @@
-var utils = require("utils/utils");
-var application = require("application");
-var frame = require("ui/frame");
+var utils = require("tns-core-modules/utils/utils");
+var application = require("tns-core-modules/application");
+var frame = require("tns-core-modules/ui/frame");
 var admob = require("./admob-common");
 
 admob._getBannerType = function (size) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-admob",
-  "version": "1.5.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/platforms/android/AndroidManifest.xml
+++ b/src/platforms/android/AndroidManifest.xml
@@ -5,6 +5,9 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
   <application>
+
+    <meta-data android:name="com.google.android.gms.ads.APPLICATION_ID" android:value="ca-app-pub-3940256099942544~6300978111" />
+
     <activity android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
               android:name="com.google.android.gms.ads.AdActivity"
               android:theme="@android:style/Theme.Translucent" />

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -11,6 +11,6 @@ repositories {
 }
 
 dependencies {
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '16.0.0'
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '+'
     compile "com.google.android.gms:play-services-ads:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
Google AdMob publishers are required to specify a <meta-data> tag with key com.google.android.gms.ads.APPLICATION_ID in their AndroidManifest.xml as of Google Mobile Ads SDK version 17.0.0. Failure to add this <meta-data> tag results in a crash with the message: `The Google Mobile Ads SDK was initialized incorrectly.`  More info can be found here: https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml

As a result from the above crash, {N} CLI is not able to start the application on device. 

Refs to: https://github.com/NativeScript/nativescript-cli/issues/4029