### PR TITLE
Change iOS request from function to property

### DIFF
--- a/src/admob.ios.js
+++ b/src/admob.ios.js
@@ -108,7 +108,7 @@ admob.createBanner = function (arg) {
 
       admob.adView.adUnitID = settings.iosBannerId;
 
-      var adRequest = GADRequest.request();
+      var adRequest = GADRequest.request;
 
       if (settings.testing) {
         var testDevices = ["Simulator"];

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-admob",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Make money with your app by using Google's AdMob ads.",
   "main": "admob",
   "nativescript": {


### PR DESCRIPTION
Seems that request from GADRequest now is a property instead of a function. Changed it accordingly.